### PR TITLE
Added basic localization support

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -49,9 +49,15 @@ extern NSString *const kAppiraterDeclinedToRate;
 #define APPIRATER_APP_ID				0000000000
 
 /*
+ Your localized app's name.
+ */
+
+#define APPIRATER_LOCALIZED_APP_NAME    [[[NSBundle mainBundle] localizedInfoDictionary] objectForKey:(NSString *)kCFBundleNameKey]
+
+/*
  Your app's name.
  */
-#define APPIRATER_APP_NAME				[[[NSBundle mainBundle] localizedInfoDictionary] objectForKey:(NSString *)kCFBundleNameKey]
+#define APPIRATER_APP_NAME				APPIRATER_LOCALIZED_APP_NAME ? APPIRATER_LOCALIZED_APP_NAME : [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleNameKey]
 
 /*
  The localized template message for displaying the rating request


### PR DESCRIPTION
I just added a basic localization support, that will only require some small changes in the Appirater header file. The changes are unobtrusive, meaning that everyone who is using the old version of Appirater can easily switch to this one, even if he/she does not make use of localization support for the application.
