### PR TITLE
Appirater no longer needs user intervention

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -94,6 +94,7 @@ NSString *templateReviewURLIpad = @"itms-apps://ax.itunes.apple.com/WebObjects/M
 + (void) load {
 	if (self == [Appirater class]) {
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidFinishLaunching:) name:UIApplicationDidFinishLaunchingNotification object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillEnterForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
 	}
 }
 
@@ -111,7 +112,11 @@ NSString *templateReviewURLIpad = @"itms-apps://ax.itunes.apple.com/WebObjects/M
 }
 
 + (void) applicationDidFinishLaunching:(NSNotification *)note {
-	[self appLaunched];
+	[self appLaunched:YES];
+}
+
++ (void) applicationWillEnterForeground:(NSNotification *)note {
+	[self appEnteredForeground:YES];
 }
 
 - (void)showRatingAlert {

--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@ Getting Started
 ---------------
 1. Add the Appirater code into your project
 2. Add the `CFNetwork` and `SystemConfiguration` frameworks to your project
-3. Call `[Appirater appLaunched:YES]` at the end of your app delegate's `application:didFinishLaunchingWithOptions:` method.
-4. Call `[Appirater appEnteredForeground:YES]` in your app delegate's `applicationWillEnterForeground:` method.
-5. (OPTIONAL) Call `[Appirater userDidSignificantEvent:YES]` when the user does something 'significant' in the app.
-6. Finally, set the `APPIRATER_APP_ID` in `Appirater.h` to your Apple provided software id.
+3. (OPTIONAL) Call `[Appirater userDidSignificantEvent:YES]` when the user does something 'significant' in the app.
+4. Finally, set the `APPIRATER_APP_ID` in `Appirater.h` to your Apple provided software id.
 
 License
 -------


### PR DESCRIPTION
Hi arashpayan,

I took advantage of the +load method to automatically register for certain notifications (UIApplicationDidFinishLaunchingNotification and UIApplicationWillEnterForegroundNotification).  With these in place, appirater no longer needs the user to put "[Appirater appLaunched:YES]" and "[Appirater appEnteredForeground:YES]" in their own code.  It's handled automatically.

I also edited the README to remove these steps from the "Getting Started" section.

Cheers,

Dave DeLong
