### PR TITLE
Changed APPIRATER_APP_ID #define to static NSString

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -46,7 +46,7 @@ extern NSString *const kAppiraterDeclinedToRate;
 /*
  Place your Apple generated software id here.
  */
-#define APPIRATER_APP_ID				301377083
+#define APPIRATER_APP_ID				@"301377083"
 
 /*
  Your app's name.

--- a/Appirater.m
+++ b/Appirater.m
@@ -339,7 +339,7 @@ NSString *templateReviewURL = @"itms-apps://ax.itunes.apple.com/WebObjects/MZSto
 	NSLog(@"APPIRATER NOTE: iTunes App Store is not supported on the iOS simulator. Unable to open App Store page.");
 #else
 	NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-	NSString *reviewURL = [templateReviewURL stringByReplacingOccurrencesOfString:@"APP_ID" withString:[NSString stringWithFormat:@"%d", APPIRATER_APP_ID]];
+	NSString *reviewURL = [templateReviewURL stringByReplacingOccurrencesOfString:@"APP_ID" withString:APPIRATER_APP_ID];
 	[userDefaults setBool:YES forKey:kAppiraterRatedCurrentVersion];
 	[userDefaults synchronize];
 	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:reviewURL]];


### PR DESCRIPTION
I tried replacing the integer app ID with a code snippet (we have like 40 different targets and are pulling the app ID out of a configuration file), and found that the code was expecting a bare integer. So I deleted the -stringWithFormat: call, and changed the #define to the @"12355" format. 

I can see arguments both ways, but this parallels the other #defines (some of which are code snippets) a bit better. 

Thanks for this project, by the way. It's well-written and a real time-saver!
