### PR TITLE
Wraps #define's in #ifdef's to allow for custom settings (via a pch file) without overwriting the framework's core header file.

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -45,6 +45,17 @@ extern NSString *const kAppiraterDeclinedToRate;
 extern NSString *const kAppiraterReminderRequestDate;
 
 /*
+ NSNotification name for popup click event
+ */
+extern NSString *const kAppiraterButtonClickedNotification;
+
+/* Sent as the object to the above notification on click */
+extern NSString *const kAppiraterNotificationObjectForDeclinedClicked;
+extern NSString *const kAppiraterNotificationObjectForRateClicked;
+extern NSString *const kAppiraterNotificationObjectForLaterClicked;
+extern NSString *const kAppiraterNotificationObjectForOtherClicked;
+
+/*
  Place your Apple generated software id here.
  */
 #ifndef APPIRATER_APP_ID

--- a/Appirater.m
+++ b/Appirater.m
@@ -48,6 +48,14 @@ NSString *const kAppiraterReminderRequestDate		= @"kAppiraterReminderRequestDate
 
 NSString *templateReviewURL = @"itms-apps://ax.itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=APP_ID";
 
+/** Notification message & objects */
+NSString *const kAppiraterButtonClickedNotification = @"kAppiraterButtonClickedNotification";
+NSString *const kAppiraterNotificationObjectForDeclinedClicked = @"kAppiraterNotificationObjectForDeclinedClicked";
+NSString *const kAppiraterNotificationObjectForRateClicked = @"kAppiraterNotificationObjectForRateClicked";
+NSString *const kAppiraterNotificationObjectForLaterClicked = @"kAppiraterNotificationObjectForLaterClicked";
+NSString *const kAppiraterNotificationObjectForOtherClicked = @"kAppiraterNotificationObjectForOtherClicked";
+
+
 @interface Appirater ()
 - (BOOL)connectedToNetwork;
 + (Appirater*)sharedInstance;
@@ -359,28 +367,45 @@ NSString *templateReviewURL = @"itms-apps://ax.itunes.apple.com/WebObjects/MZSto
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
 	NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
 	
+    NSString *notifObj;
+    
 	switch (buttonIndex) {
 		case 0:
 		{
 			// they don't want to rate it
 			[userDefaults setBool:YES forKey:kAppiraterDeclinedToRate];
 			[userDefaults synchronize];
+            
+            // Msg for notification
+            notifObj = kAppiraterNotificationObjectForDeclinedClicked;
+            
 			break;
 		}
 		case 1:
 		{
 			// they want to rate it
 			[Appirater rateApp];
+            
+            notifObj = kAppiraterNotificationObjectForRateClicked;
+            
 			break;
 		}
 		case 2:
 			// remind them later
 			[userDefaults setDouble:[[NSDate date] timeIntervalSince1970] forKey:kAppiraterReminderRequestDate];
 			[userDefaults synchronize];
+            
+            notifObj = kAppiraterNotificationObjectForLaterClicked;
+            
 			break;
 		default:
+            
+            notifObj = kAppiraterNotificationObjectForOtherClicked;
 			break;
 	}
+    
+    // Send the notification
+    [[NSNotificationCenter defaultCenter] postNotificationName:kAppiraterButtonClickedNotification object:notifObj];
 }
 
 @end


### PR DESCRIPTION
Just discovered this works when you place your settings in a precompiled header file.  Personally I think it's better than mod'ing the framework's core files.
