### PR TITLE
Added bad impressions count.

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -43,6 +43,7 @@ extern NSString *const kAppiraterCurrentVersion;
 extern NSString *const kAppiraterRatedCurrentVersion;
 extern NSString *const kAppiraterDeclinedToRate;
 extern NSString *const kAppiraterReminderRequestDate;
+extern NSString *const kAppiraterBadImpressionsCount;
 
 /*
  Your localized app's name.
@@ -202,6 +203,13 @@ extern NSString *const kAppiraterReminderRequestDate;
  looks and making sure the link to your app's review page works.
  */
 + (void) setDebug:(BOOL)debug;
+
+/*
+ Tells Appirater that the user has experienced unpleasant situation like crash etc.
+ In the wake of that, Appirater will not display "Rate ..." alert because user is
+ not likely to give us 5 stars.
+ */
++ (void)userDidExperienceUnpleasantSituation;
 
 @end
 

--- a/Appirater.m
+++ b/Appirater.m
@@ -45,6 +45,7 @@ NSString *const kAppiraterCurrentVersion			= @"kAppiraterCurrentVersion";
 NSString *const kAppiraterRatedCurrentVersion		= @"kAppiraterRatedCurrentVersion";
 NSString *const kAppiraterDeclinedToRate			= @"kAppiraterDeclinedToRate";
 NSString *const kAppiraterReminderRequestDate		= @"kAppiraterReminderRequestDate";
+NSString *const kAppiraterBadImpressionsCount       = @"kAppiraterBadImpressionsCount";
 
 NSString *templateReviewURL = @"itms-apps://ax.itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=APP_ID";
 NSString *templateReviewURLiOS6 = @"itms-apps://itunes.apple.com/LANGUAGE/app/idAPP_ID";
@@ -179,6 +180,11 @@ static BOOL _debug = NO;
 	// has the user already rated the app?
 	if ([userDefaults boolForKey:kAppiraterRatedCurrentVersion])
 		return NO;
+    
+    // has user encoutered unpleasant situation in the app? e.g. crashes
+    if ([userDefaults integerForKey:kAppiraterBadImpressionsCount] > 0) {
+        return NO;
+    }
 	
 	// if the user wanted to be reminded later, has enough time passed?
 	NSDate *reminderRequestDate = [NSDate dateWithTimeIntervalSince1970:[userDefaults doubleForKey:kAppiraterReminderRequestDate]];
@@ -233,6 +239,7 @@ static BOOL _debug = NO;
 		[userDefaults setBool:NO forKey:kAppiraterRatedCurrentVersion];
 		[userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
 		[userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
+        [userDefaults setInteger:0 forKey:kAppiraterBadImpressionsCount];
 	}
 	
 	[userDefaults synchronize];
@@ -281,6 +288,7 @@ static BOOL _debug = NO;
 		[userDefaults setBool:NO forKey:kAppiraterRatedCurrentVersion];
 		[userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
 		[userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
+        [userDefaults setInteger:0 forKey:kAppiraterBadImpressionsCount];
 	}
 	
 	[userDefaults synchronize];
@@ -351,6 +359,15 @@ static BOOL _debug = NO;
                    ^{
                        [[Appirater sharedInstance] incrementSignificantEventAndRate:canPromptForRating];
                    });
+}
+
++ (void)userDidExperienceUnpleasantSituation
+{
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    NSInteger dissatisfactionRate = [userDefaults integerForKey:kAppiraterBadImpressionsCount];
+    dissatisfactionRate++;
+    [userDefaults setInteger:dissatisfactionRate forKey:kAppiraterBadImpressionsCount];
+    [userDefaults synchronize];
 }
 
 + (void)rateApp {


### PR DESCRIPTION
When user experience unpleasant situation e.g crash, you can say not to show prompt by calling userDidExperienceUnpleasantSituation method.
