### PR TITLE
Allow configuration via Appirater.plist, support landscape mode.

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -125,6 +125,14 @@ extern NSString *const kAppiraterReminderRequestDate;
 #define APPIRATER_TIME_BEFORE_REMINDING		1	// double
 
 /*
+ Due to screen dimension limitations, only one of the 'Remind me later' or
+ the 'No, thanks' button may be shown. This setting specifies how many times
+ the 'Remind me later' button should be shown before switching to the 'No thanks'
+ button. This setting does not have any effect while in portrait mode.
+ */
+#define APPIRATER_LANDSCAPE_HIDE_CANCEL_COUNT	5	// integer
+
+/*
  'YES' will show the Appirater alert everytime. Useful for testing how your message
  looks and making sure the link to your app's review page works.
  */

--- a/Appirater.h
+++ b/Appirater.h
@@ -34,7 +34,7 @@
  * Copyright 2012 Arash Payan. All rights reserved.
  */
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 extern NSString *const kAppiraterFirstUseDate;
 extern NSString *const kAppiraterUseCount;
@@ -47,7 +47,7 @@ extern NSString *const kAppiraterReminderRequestDate;
 /*
  Place your Apple generated software id here.
  */
-#define APPIRATER_APP_ID				301377083
+#define APPIRATER_APP_ID				[bundle objectForInfoDictionaryKey:@"iTunesAppID"]
 
 
 /*
@@ -64,14 +64,12 @@ extern NSString *const kAppiraterReminderRequestDate;
  This is the message your users will see once they've passed the day+launches
  threshold.
  */
-#define APPIRATER_LOCALIZED_MESSAGE     NSLocalizedString(@"If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!", nil)
-#define APPIRATER_MESSAGE				[NSString stringWithFormat:APPIRATER_LOCALIZED_MESSAGE, APPIRATER_APP_NAME]
+#define APPIRATER_MESSAGE               NSLocalizedString(@"If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!", nil)
 
 /*
  This is the title of the message alert that users will see.
  */
-#define APPIRATER_LOCALIZED_MESSAGE_TITLE   NSLocalizedString(@"Rate %@", nil)
-#define APPIRATER_MESSAGE_TITLE             [NSString stringWithFormat:APPIRATER_LOCALIZED_MESSAGE_TITLE, APPIRATER_APP_NAME]
+#define APPIRATER_MESSAGE_TITLE         NSLocalizedString(@"Rate %@", nil)
 
 /*
  The text of the button that rejects reviewing the app.
@@ -81,8 +79,7 @@ extern NSString *const kAppiraterReminderRequestDate;
 /*
  Text of button that will send user to app review page.
  */
-#define APPIRATER_LOCALIZED_RATE_BUTTON NSLocalizedString(@"Rate %@", nil)
-#define APPIRATER_RATE_BUTTON			[NSString stringWithFormat:APPIRATER_LOCALIZED_RATE_BUTTON, APPIRATER_APP_NAME]
+#define APPIRATER_RATE_BUTTON           NSLocalizedString(@"Rate %@", nil)
 
 /*
  Text for button to remind the user to review later.

--- a/Appirater.h
+++ b/Appirater.h
@@ -136,7 +136,7 @@ extern NSString *const kAppiraterReminderRequestDate;
  'YES' will show the Appirater alert everytime. Useful for testing how your message
  looks and making sure the link to your app's review page works.
  */
-#define APPIRATER_DEBUG				YES
+#define APPIRATER_DEBUG				NO
 
 @interface Appirater : NSObject <UIAlertViewDelegate> {
 

--- a/Appirater.plist.sample
+++ b/Appirater.plist.sample
@@ -27,6 +27,8 @@
     <integer>-1</integer>
     <key>TimeBeforeReminding</key>
     <integer>1</integer>
+    <key>LandscapeHideCancelCount</key>
+    <integer>5</integer>
     <key>Debug</key>
     <false/>
 </dict>

--- a/Appirater.plist.sample
+++ b/Appirater.plist.sample
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- All these options have suitable defaults -->
+    <!-- See Appirater.h for more information -->
+    <!-- %@ is always replaced with AppName -->
+    <key>AppID</key>
+    <string>1234</string>
+    <key>AppName</key>
+    <string>Appirater</string>
+    <key>Message</key>
+    <string>If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!</string>
+    <key>MessageTitle</key>
+    <string>Rate %@</string>
+    <key>CancelButton</key>
+    <string>No, Thanks</string>
+    <key>RateButton</key>
+    <string>Rate %@</string>
+    <key>RateLater</key>
+    <string>Remind me later</string>
+    <key>DaysUntilPrompt</key>
+    <integer>30</integer>
+    <key>UsesUntilPrompt</key>
+    <integer>20</integer>
+    <key>SigEventsUntilPrompt</key>
+    <integer>-1</integer>
+    <key>TimeBeforeReminding</key>
+    <integer>1</integer>
+    <key>Debug</key>
+    <false/>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Getting Started
 3. Call `[Appirater appLaunched:YES]` at the end of your app delegate's `application:didFinishLaunchingWithOptions:` method.
 4. Call `[Appirater appEnteredForeground:YES]` in your app delegate's `applicationWillEnterForeground:` method.
 5. (OPTIONAL) Call `[Appirater userDidSignificantEvent:YES]` when the user does something 'significant' in the app.
-6. Finally, set the `APPIRATER_APP_ID` in `Appirater.h` to your Apple provided software id.
+6. Set an Info.plist string entry `iTunesAppID` to your Apple provided software id.
+7. Optionally, include an Appirater.plist file containing customization parameters (see Appirater.plist.sample)
 
 License
 -------


### PR DESCRIPTION
Hi, I added these changes to avoid having to change the code to tailor to a specific usage. Instead, all the configuration options may be specified in an Appirater.plist file (sample included). The plist may be omitted, in which case sensible defaults apply (just as before). Lastly, the AppID may be specified in the Info.plist.

Also added a small change to support landscape orientation (before, the dialog was trimmed if shown in landscape).

Lastly, made debug default to NO. Debug may still be turned on by using an Appirater.plist file.
