### PR TITLE
Update de.lproj/AppiraterLocalizable.strings

### DIFF
--- a/de.lproj/AppiraterLocalizable.strings
+++ b/de.lproj/AppiraterLocalizable.strings
@@ -1,4 +1,4 @@
-"If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!" = "Wenn Sie %@ gerne nutzen, würden Sie sich bitte einen Moment Zeit nehmen, um zu bewerten? Es dauert nicht mehr als eine Minute. Vielen Dank für Ihre Unterstützung!";
+"If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!" = "Wenn Sie %@ gerne nutzen, würden Sie sich bitte einen Moment Zeit nehmen, um zu bewerten? Es dauert nicht länger als eine Minute. Vielen Dank für Ihre Unterstützung!";
 "Rate %@" = "Bewerte %@";
 "No, Thanks" = "Nein, Danke";
 "Remind me later" = "Später erinnern";


### PR DESCRIPTION
When describing a time span, "länger" is correct, not "mehr"
