### PR TITLE
Fixed spelling error in Czech localization

### DIFF
--- a/cs.lproj/AppiraterLocalizable.strings
+++ b/cs.lproj/AppiraterLocalizable.strings
@@ -1,4 +1,4 @@
-"If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!" = "Pokud se Vám líbí aplikace %@, mohli ji prosím ohodnotit v App Store? Zabere to jen chvilku. Díky za Vaši podporu!";
+"If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!" = "Pokud se Vám aplikace líbí%@, mohli byste ji prosím ohodnotit v App Store? Zabere to jen chvilku. Díky za Vaši podporu!";
 "Rate %@" = "Ohodnotit %@";
 "No, Thanks" = "Ne, díky";
 "Remind me later" = "Možná později";


### PR DESCRIPTION
There is a spelling error in original translation. You probably have no way to check what I fixed. I contacted Sarsonj (he made original czech localisation) and he asked me to commit this change.
