### PR TITLE
It's unsafe_unretained, not unsafe_unreferenced.

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -93,7 +93,7 @@ extern NSString *const kAppiraterReminderRequestDate;
 #if __has_feature(objc_arc_weak)
 @property(nonatomic, weak) NSObject <AppiraterDelegate> *delegate;
 #else
-@property(nonatomic, unsafe_unreferenced) NSObject <AppiraterDelegate> *delegate;
+@property(nonatomic, unsafe_unretained) NSObject <AppiraterDelegate> *delegate;
 #endif
 
 /*


### PR DESCRIPTION
D'oh. Thanks for the heads up, rdetert (issue #72).

Sorry for the confusion, can't believe I screwed this up.
