### PR TITLE
Update Appirater.h

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -48,7 +48,7 @@ extern NSString *const kAppiraterReminderRequestDate;
 /*
  Your localized app's name.
  */
-#define APPIRATER_LOCALIZED_APP_NAME    [[[NSBundle mainBundle] localizedInfoDictionary] objectForKey:(NSString *)kCFBundleNameKey]
+#define APPIRATER_LOCALIZED_APP_NAME    [[[NSBundle mainBundle] localizedInfoDictionary] objectForKey:@"CFBundleDisplayName"]
 
 /*
  Your app's name.


### PR DESCRIPTION
fixed APPIRATER_LOCALIZED_APP_NAME bug, It should be using @"CFBundleDisplayName", not (NSString*)kCFBundleNameKey
