### PR TITLE
Add compiler warning if not compiled with ARC

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -38,6 +38,10 @@
 #import <SystemConfiguration/SCNetworkReachability.h>
 #include <netinet/in.h>
 
+#if ! __has_feature(objc_arc)
+#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 NSString *const kAppiraterFirstUseDate				= @"kAppiraterFirstUseDate";
 NSString *const kAppiraterUseCount					= @"kAppiraterUseCount";
 NSString *const kAppiraterSignificantEventCount		= @"kAppiraterSignificantEventCount";


### PR DESCRIPTION
Regarding: https://github.com/arashpayan/appirater/pull/94

Maybe add a compiler warning as a hint if Appirater is not compiled with ARC (e.g. if the files are imported to an other non-arc project)
