### PR TITLE
Updates the README with Objective-C syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ Configuration
 
 Appirater provides class methods to configure its behavior. See [`Appirater.h`] [Appirater.h] for more information.
 
-    [Appirater setAppId:@"552035781"];
-    [Appirater setDaysUntilPrompt:1];
-    [Appirater setUsesUntilPrompt:10];
-    [Appirater setSignificantEventsUntilPrompt:-1];
-    [Appirater setTimeBeforeReminding:2];
-    [Appirater setDebug:YES];
+```objc
+[Appirater setAppId:@"552035781"];
+[Appirater setDaysUntilPrompt:1];
+[Appirater setUsesUntilPrompt:10];
+[Appirater setSignificantEventsUntilPrompt:-1];
+[Appirater setTimeBeforeReminding:2];
+[Appirater setDebug:YES];
+```
 
 License
 -------


### PR DESCRIPTION
This pull uses Github's pygments support to highlight the code block in the README.

![On the Tin](http://3.bp.blogspot.com/_qbj5htnD4tQ/SrASvimO9NI/AAAAAAAABIM/CdmyHbNRPt0/s400/ronseal.jpg)
