### PR TITLE
Fixed Issue #100

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -387,7 +387,15 @@ static BOOL _modalOpen = false;
         }
     }
     
-    return [[[window subviews] objectAtIndex:0] nextResponder];
+    for (UIView *subView in [window subviews])
+    {
+        UIResponder *responder = [subView nextResponder];
+        if([responder isKindOfClass:[UIViewController class]]) {
+            return responder;
+        }
+    }
+    
+    return nil;
 }
 
 + (void)rateApp {


### PR DESCRIPTION
In method + (id)getRootViewController It was possible that another class than a UIViewController Class gets returned, so a call to presendtViewController:.... would result in a crash. 
Fix:
Iterating over subviews of UIWindow and checking if the responder is kind of UIViewController and only return it if the result is positive.
