### PR TITLE
Added call to show the prompt (the rating alert) explicitly

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -144,7 +144,8 @@ extern NSString *const kAppiraterReminderRequestDate;
 
 /*
  Tells Appirater to show the prompt (a rating alert). The prompt will be showed
- if there is connection available and the user hasn't rated current version.
+ if there is connection available, the user hasn't declined to rate
+ or hasn't rated current version.
  
  You could call to show the prompt regardless Appirater settings,
  e.g., in case of some special event in your app.

--- a/Appirater.m
+++ b/Appirater.m
@@ -337,6 +337,10 @@ static BOOL _modalOpen = false;
 	}
 }
 
+- (BOOL)userHasDeclinedToRate {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:kAppiraterDeclinedToRate];
+}
+
 - (BOOL)userHasRatedCurrentVersion {
     return [[NSUserDefaults standardUserDefaults] boolForKey:kAppiraterRatedCurrentVersion];
 }
@@ -382,6 +386,7 @@ static BOOL _modalOpen = false;
 
 + (void)showPrompt {
     if ([[Appirater sharedInstance] connectedToNetwork]
+        && ![[Appirater sharedInstance] userHasDeclinedToRate]
         && ![[Appirater sharedInstance] userHasRatedCurrentVersion]) {
         [[Appirater sharedInstance] showRatingAlert];
     }


### PR DESCRIPTION
In some cases you may want to show the prompt for rating explicitly regardless Appirater settings.
