### PR TITLE
Added option to force Appirater always to open App Store (instead of SKS...

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -224,6 +224,11 @@ extern NSString *const kAppiraterReminderRequestDate;
  */
 + (void)setUsesAnimation:(BOOL)animation;
 
+/*
+ If set to YES, Appirater will open App Store link (instead of SKStoreProductViewController on iOS 6). Default NO.
+ */
++ (void)setOpenInAppStore:(BOOL)openInAppStore;
+
 @end
 
 

--- a/Appirater.m
+++ b/Appirater.m
@@ -60,6 +60,7 @@ static double _timeBeforeReminding = 1;
 static BOOL _debug = NO;
 static id<AppiraterDelegate> _delegate;
 static BOOL _usesAnimation = TRUE;
+static BOOL _openInAppStore = NO;
 static UIStatusBarStyle _statusBarStyle;
 static BOOL _modalOpen = false;
 
@@ -104,6 +105,9 @@ static BOOL _modalOpen = false;
 }
 + (void)setUsesAnimation:(BOOL)animation {
 	_usesAnimation = animation;
+}
++ (void)setOpenInAppStore:(BOOL)openInAppStore {
+    _openInAppStore = openInAppStore;
 }
 + (void)setStatusBarStyle:(UIStatusBarStyle)style {
 	_statusBarStyle = style;
@@ -420,7 +424,7 @@ static BOOL _modalOpen = false;
 	[userDefaults synchronize];
 
 	//Use the in-app StoreKit view if available (iOS 6) and imported. This works in the simulator.
-	if (NSStringFromClass([SKStoreProductViewController class]) != nil) {
+	if (!_openInAppStore && NSStringFromClass([SKStoreProductViewController class]) != nil) {
 		
 		SKStoreProductViewController *storeViewController = [[SKStoreProductViewController alloc] init];
 		NSNumber *appId = [NSNumber numberWithInteger:_appId.integerValue];


### PR DESCRIPTION
...toreProductViewController in iOS 6)

Sometime you don't want use SKStoreProductViewController, e.g., due autorotation issues.
