### PR TITLE
Delegate variable is strong

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -58,7 +58,7 @@ static NSInteger _usesUntilPrompt = 20;
 static NSInteger _significantEventsUntilPrompt = -1;
 static double _timeBeforeReminding = 1;
 static BOOL _debug = NO;
-static id<AppiraterDelegate> _delegate;
+__weak static id<AppiraterDelegate> _delegate;
 static BOOL _usesAnimation = TRUE;
 static BOOL _openInAppStore = NO;
 static UIStatusBarStyle _statusBarStyle;


### PR DESCRIPTION
Shouldn't

```
static id<AppiraterDelegate> _delegate;
```

be

```
__weak static id<AppiraterDelegate> _delegate;
```

instead?

Usually, all delegates are weak to avoid retain cycles in delegates of non-singleton objects. This shouldn't be as much of a problem with a Appirater, which only has class methods (similar to a singleton) but still I think it's best practice to declare the delegate as `__weak`.
