### PR TITLE
Avoid showing the user multiple rating alerts

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -85,12 +85,9 @@ extern NSString *const kAppiraterReminderRequestDate;
  */
 #define APPIRATER_RATE_LATER			NSLocalizedStringFromTable(@"Remind me later", @"AppiraterLocalizable", nil)
 
-@interface Appirater : NSObject <UIAlertViewDelegate, SKStoreProductViewControllerDelegate> {
+@interface Appirater : NSObject <UIAlertViewDelegate, SKStoreProductViewControllerDelegate>
 
-	UIAlertView		*ratingAlert;
-}
-
-@property(nonatomic, strong) UIAlertView *ratingAlert;
+@property(nonatomic, weak) UIAlertView *ratingAlert;
 #if __has_feature(objc_arc_weak)
 @property(nonatomic, weak) NSObject <AppiraterDelegate> *delegate;
 #else

--- a/Appirater.m
+++ b/Appirater.m
@@ -73,9 +73,7 @@ static BOOL _modalOpen = false;
 - (void)hideRatingAlert;
 @end
 
-@implementation Appirater 
-
-@synthesize ratingAlert;
+@implementation Appirater
 
 + (void) setAppId:(NSString *)appId {
     _appId = appId;
@@ -164,6 +162,7 @@ static BOOL _modalOpen = false;
 }
 
 - (void)showRatingAlert {
+    if (self.ratingAlert) return; // We never want to show multiple alerts to the user
 	UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:APPIRATER_MESSAGE_TITLE
 														 message:APPIRATER_MESSAGE
 														delegate:self


### PR DESCRIPTION
We've had an annoying issue where appirater would sometimes show the user multiple alert dialogs. I have fixed this by maintaining a weak reference to the `UIAlertView` dialog and refusing to present if the reference is non-nil. I also dropped the interval ivar since it looked most properties were auto-synthesized and Xcode was showing a warning.
