### PR TITLE
Add __weak for delegate on iOS 5+ only

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -58,7 +58,11 @@ static NSInteger _usesUntilPrompt = 20;
 static NSInteger _significantEventsUntilPrompt = -1;
 static double _timeBeforeReminding = 1;
 static BOOL _debug = NO;
-__weak static id<AppiraterDelegate> _delegate;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_5_0
+	static id<AppiraterDelegate> _delegate;
+#else
+	__weak static id<AppiraterDelegate> _delegate;
+#endif
 static BOOL _usesAnimation = TRUE;
 static BOOL _openInAppStore = NO;
 static UIStatusBarStyle _statusBarStyle;


### PR DESCRIPTION
In order to allow compilation for applications targeting iOS 4.3 without losing __weak benefits for further iOS versions, you should apply conditional compilation.
