### PR TITLE
added + (void) setOnlyAlertAfterSignificantEvents:(BOOL)promptAfterEvent;

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -212,6 +212,18 @@ extern NSString *const kAppiraterReminderRequestDate;
 
 
 /*
+ Present the alert if all requirements are met and ONLY after a significant 
+ event. So the alert will not pop up automatically on app start or becoming 
+ the foreground app if you pass in 'YES' to this method. This is particular 
+ useful if you have some sort of login and want to wait with the rating alert 
+ until login has completed. The default value is 'NO'.
+ ATTENTION: Specifying 'YES' and don't ever call 
+ + (void)userDidSignificantEvent:(BOOL)canPromptForRating 
+ will lead to that the alert is never shown.
+ */
++ (void) setOnlyAlertAfterSignificantEvents:(BOOL)promptAfterEvent;
+
+/*
  Once the rating alert is presented to the user, they might select
  'Remind me later'. This value specifies how long (in days) Appirater
  will wait before reminding them.

--- a/Appirater.m
+++ b/Appirater.m
@@ -56,6 +56,7 @@ static NSString *_appId;
 static double _daysUntilPrompt = 30;
 static NSInteger _usesUntilPrompt = 20;
 static NSInteger _significantEventsUntilPrompt = -1;
+static BOOL _onlyAlertAfterSignificantEvents = NO;
 static double _timeBeforeReminding = 1;
 static BOOL _debug = NO;
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_5_0
@@ -95,6 +96,10 @@ static BOOL _modalOpen = false;
 
 + (void) setSignificantEventsUntilPrompt:(NSInteger)value {
     _significantEventsUntilPrompt = value;
+}
+
++ (void) setOnlyAlertAfterSignificantEvents:(BOOL)promptAfterEvent {
+	_onlyAlertAfterSignificantEvents = promptAfterEvent;
 }
 
 + (void) setTimeBeforeReminding:(double)value {
@@ -322,7 +327,8 @@ static BOOL _modalOpen = false;
 	
 	if (canPromptForRating &&
 		[self ratingConditionsHaveBeenMet] &&
-		[self connectedToNetwork])
+		[self connectedToNetwork] &&
+		!_onlyAlertAfterSignificantEvents)
 	{
         dispatch_async(dispatch_get_main_queue(),
                        ^{


### PR DESCRIPTION
I need to present the alert only after significant events occurred. The alert should _NOT_ be presented automatically on app start.

This is my solution.
