### PR TITLE
Cocoa Pods installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ the library check out the [Appirater group] [appiratergroup].
 
 Getting Started
 ---------------
+
+###Cocoapods
+If you're new to Cocoapods [watch this](http://nsscreencast.com/episodes/5-cocoapods). To add Appirater to your app, add `pod "Appirater"` to your Podfile.
+
+Cocoapods support is still experimental, and might not work in all use cases. If you experience problems, open an issue and install via Git submodule
+
+###Git submodule
 1. Add the Appirater code into your project.
 2. If your project doesn't use ARC, add the `-fobjc-arc` compiler flag to `Appirater.m` in your target's Build Phases » Compile Sources section.
 3. Add the `CFNetwork`, `SystemConfiguration`, and `StoreKit` frameworks to your project. Be sure to **change Required to Optional** for StoreKit in your target's Build Phases » Link Binary with Libraries section.


### PR DESCRIPTION
I added instructions to the README.md for cocoa pods installation. I pulled the video and warning from the [sharekit](https://github.com/ShareKit/ShareKit/wiki/Installing-sharekit/076eb363be39668961b3f2c640855d181bc684ac) cocoa pods installation instructions. I figured this could save time over having to lookup the pod on [cocoapods.org](http://cocoapods.org).
