### PR TITLE
Move lproj directories to Appirater.bundle when using CocoaPods

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -60,30 +60,30 @@ extern NSString *const kAppiraterReminderRequestDate;
  This is the message your users will see once they've passed the day+launches
  threshold.
  */
-#define APPIRATER_LOCALIZED_MESSAGE     NSLocalizedStringFromTable(@"If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!", @"AppiraterLocalizable", nil)
+#define APPIRATER_LOCALIZED_MESSAGE     NSLocalizedStringFromTableInBundle(@"If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!", @"AppiraterLocalizable", [Appirater bundle], nil)
 #define APPIRATER_MESSAGE				[NSString stringWithFormat:APPIRATER_LOCALIZED_MESSAGE, APPIRATER_APP_NAME]
 
 /*
  This is the title of the message alert that users will see.
  */
-#define APPIRATER_LOCALIZED_MESSAGE_TITLE   NSLocalizedStringFromTable(@"Rate %@", @"AppiraterLocalizable", nil)
+#define APPIRATER_LOCALIZED_MESSAGE_TITLE   NSLocalizedStringFromTableInBundle(@"Rate %@", @"AppiraterLocalizable", [Appirater bundle], nil)
 #define APPIRATER_MESSAGE_TITLE             [NSString stringWithFormat:APPIRATER_LOCALIZED_MESSAGE_TITLE, APPIRATER_APP_NAME]
 
 /*
  The text of the button that rejects reviewing the app.
  */
-#define APPIRATER_CANCEL_BUTTON			NSLocalizedStringFromTable(@"No, Thanks", @"AppiraterLocalizable", nil)
+#define APPIRATER_CANCEL_BUTTON			NSLocalizedStringFromTableInBundle(@"No, Thanks", @"AppiraterLocalizable", [Appirater bundle], nil)
 
 /*
  Text of button that will send user to app review page.
  */
-#define APPIRATER_LOCALIZED_RATE_BUTTON NSLocalizedStringFromTable(@"Rate %@", @"AppiraterLocalizable", nil)
+#define APPIRATER_LOCALIZED_RATE_BUTTON NSLocalizedStringFromTableInBundle(@"Rate %@", @"AppiraterLocalizable", [Appirater bundle], nil)
 #define APPIRATER_RATE_BUTTON			[NSString stringWithFormat:APPIRATER_LOCALIZED_RATE_BUTTON, APPIRATER_APP_NAME]
 
 /*
  Text for button to remind the user to review later.
  */
-#define APPIRATER_RATE_LATER			NSLocalizedStringFromTable(@"Remind me later", @"AppiraterLocalizable", nil)
+#define APPIRATER_RATE_LATER			NSLocalizedStringFromTableInBundle(@"Remind me later", @"AppiraterLocalizable", [Appirater bundle], nil)
 
 @interface Appirater : NSObject <UIAlertViewDelegate, SKStoreProductViewControllerDelegate> {
 
@@ -239,8 +239,27 @@ extern NSString *const kAppiraterReminderRequestDate;
  */
 + (void)setOpenInAppStore:(BOOL)openInAppStore;
 
+/*
+ If set to YES, the main bundle will always be used to load localized strings.
+ Set this to YES if you have provided your own custom localizations in AppiraterLocalizable.strings
+ in your main bundle.  Default is NO.
+ */
++ (void)setAlwaysUseMainBundle:(BOOL)useMainBundle;
+
 @end
 
+
+/*
+ Methods in this interface are public out of necessity, but may change without notice
+ */
+@interface Appirater(Unsafe)
+
+/*
+ The bundle localized strings will be loaded from.
+*/
++(NSBundle *)bundle;
+
+@end
 
 @interface Appirater(Deprecated)
 

--- a/Appirater.m
+++ b/Appirater.m
@@ -67,6 +67,7 @@ static BOOL _usesAnimation = TRUE;
 static BOOL _openInAppStore = NO;
 static UIStatusBarStyle _statusBarStyle;
 static BOOL _modalOpen = false;
+static BOOL _alwaysUseMainBundle = NO;
 
 @interface Appirater ()
 - (BOOL)connectedToNetwork;
@@ -118,6 +119,29 @@ static BOOL _modalOpen = false;
 }
 + (void)setModalOpen:(BOOL)open {
 	_modalOpen = open;
+}
++ (void)setAlwaysUseMainBundle:(BOOL)alwaysUseMainBundle {
+    _alwaysUseMainBundle = alwaysUseMainBundle;
+}
+
++ (NSBundle *)bundle
+{
+    NSBundle *bundle;
+
+    if (_alwaysUseMainBundle) {
+        bundle = [NSBundle mainBundle];
+    } else {
+        NSURL *appiraterBundleURL = [[NSBundle mainBundle] URLForResource:@"Appirater" withExtension:@"bundle"];
+
+        if (appiraterBundleURL) {
+            // Appirater.bundle will likely only exist when used via CocoaPods
+            bundle = [NSBundle bundleWithURL:appiraterBundleURL];
+        } else {
+            bundle = [NSBundle mainBundle];
+        }
+    }
+
+    return bundle;
 }
 
 - (BOOL)connectedToNetwork {

--- a/Appirater.podspec
+++ b/Appirater.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author                = { 'Arash Payan' => 'arash.payan@gmail.com' }
   s.source                = { :git => 'https://github.com/arashpayan/appirater.git', :tag => '1.0.5' }
   s.source_files          = '*.{h,m}'
-  s.resources             = '*.lproj'
+  s.resource_bundles      = { 'Appirater' => ['*.lproj'] }
   s.requires_arc          = true
   s.frameworks            = 'CFNetwork', 'SystemConfiguration'
   s.weak_framework        = 'StoreKit'


### PR DESCRIPTION
### Issues

When using Appirater via CocoaPods, the `lproj` directories are copied to the root of the main bundle. This causes two issues:
1. They conflict with any localization in the main app.
2. The App Store detects these localized bundles and assumes the app is fully localized into all 25+ languages Appirater supports. [These Google results](https://www.google.com/search?q=site:itunes.apple.com+Languages:+English,+Bokm%C3%A5l,+Norwegian,+Catalan,+Czech,+Danish,+Dutch,+Finnish,+French,+German,+Greek,+Hebrew,+Hungarian,+Indonesian,+Italian,+Japanese,+Korean,+Polish,+Portuguese,+Romanian,+Russian,+Simplified+Chinese,+Slovak,+Spanish,+Swedish,+Traditional+Chinese,+Turkish&ie=UTF-8&oe=UTF-8) suggest this affects more than 1000 apps.
### Solution

CocoaPods [recommends](http://docs.cocoapods.org/specification.html#resource_bundles) setting `spec.resource_bundles` instead of `spec.resources` to avoid the collision from issue 1. To support this use case, the code checks if `Appirater.bundle` exists. If it does, it uses the string table from that bundle. If it doesn’t exist, which will be the case if the developer is using Appirater via a submodule or other method, then the main bundle will be used, as it is today.
### Caveat

This is _not_ backwards-compatible for users who have provided custom strings via their own `AppiraterLocalizable.strings`. These users must call the new method `[Appirater setAlwaysUseMainBundle:YES]`. To maintain [semantic versioning](http://semver.org), Appirater’s major version number should be incremented (e.g., it should become 2.0) after this is merged.
### Note for those wishing to work around the second issue before this is merged.

You can use the `Podspec` from this pull request locally:

``` ruby
pod 'Appirater', :podspec => 'Vendor/Appirater.podspec'
```

You’ll need to manually create/copy `AppiraterLocalizable.strings` to any localized bundle(s) you have.
