### PR TITLE
use different review URL for iOS 7

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -51,6 +51,7 @@ NSString *const kAppiraterDeclinedToRate			= @"kAppiraterDeclinedToRate";
 NSString *const kAppiraterReminderRequestDate		= @"kAppiraterReminderRequestDate";
 
 NSString *templateReviewURL = @"itms-apps://ax.itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?type=Purple+Software&id=APP_ID";
+NSString *templateReviewURLiOS7 = @"itms-apps://itunes.apple.com/LANGUAGE/app/idAPP_ID";
 
 static NSString *_appId;
 static double _daysUntilPrompt = 30;
@@ -494,6 +495,13 @@ static BOOL _alwaysUseMainBundle = NO;
 		NSLog(@"APPIRATER NOTE: iTunes App Store is not supported on the iOS simulator. Unable to open App Store page.");
 		#else
 		NSString *reviewURL = [templateReviewURL stringByReplacingOccurrencesOfString:@"APP_ID" withString:[NSString stringWithFormat:@"%@", _appId]];
+
+		// iOS 7 needs a different templateReviewURL @see https://github.com/arashpayan/appirater/issues/131
+		if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0) {
+			reviewURL = [templateReviewURLiOS7 stringByReplacingOccurrencesOfString:@"APP_ID" withString:[NSString stringWithFormat:@"%@", _appId]];
+			reviewURL = [reviewURL stringByReplacingOccurrencesOfString:@"LANGUAGE" withString:[NSString stringWithFormat:@"%@", [[NSLocale preferredLanguages] objectAtIndex:0]]];
+		}
+
 		[[UIApplication sharedApplication] openURL:[NSURL URLWithString:reviewURL]];
 		#endif
 	}


### PR DESCRIPTION
#131 use different App Store URL template for iOS 7 since the existing one results in a blank page. Credit to @Gerharbo's commit 96bd885b16ceff985fbb79a567444053787826eb for #50 as I used that as a basis for this fix.

Note that the "fix" for iOS 6 wasn't needed a few weeks after iOS 6 was released, so if history is any indication, this fix for iOS 7 might not be needed a few weeks after the public release of iOS 7. In the meantime, this fix will prevent iOS 7 users from seeing a blank page when they attempt to review an app.
