### PR TITLE
Let it compile with old Xcode

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -485,7 +485,9 @@ static BOOL _alwaysUseMainBundle = NO;
 			[self setModalOpen:YES];
 			//Temporarily use a black status bar to match the StoreKit view.
 			[self setStatusBarStyle:[UIApplication sharedApplication].statusBarStyle];
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
 			[[UIApplication sharedApplication]setStatusBarStyle:UIStatusBarStyleLightContent animated:_usesAnimation];
+#endif
 		}];
 	
 	//Use the standard openUrl method if StoreKit is unavailable.


### PR DESCRIPTION
We still have a little time left for iOS6 development. If you are maintaining 2 xcode this is needed. (Of course the code can be deleted soon...)
