### PR TITLE
Implemented a dataSource protocol to use custom literals

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -36,6 +36,7 @@
 
 #import <Foundation/Foundation.h>
 #import "AppiraterDelegate.h"
+#import "AppiraterDataSource.h"
 #import <StoreKit/StoreKit.h>
 
 extern NSString *const kAppiraterFirstUseDate;
@@ -45,45 +46,6 @@ extern NSString *const kAppiraterCurrentVersion;
 extern NSString *const kAppiraterRatedCurrentVersion;
 extern NSString *const kAppiraterDeclinedToRate;
 extern NSString *const kAppiraterReminderRequestDate;
-
-/*
- Your localized app's name.
- */
-#define APPIRATER_LOCALIZED_APP_NAME    [[[NSBundle mainBundle] localizedInfoDictionary] objectForKey:@"CFBundleDisplayName"]
-
-/*
- Your app's name.
- */
-#define APPIRATER_APP_NAME				APPIRATER_LOCALIZED_APP_NAME ? APPIRATER_LOCALIZED_APP_NAME : [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"]
-
-/*
- This is the message your users will see once they've passed the day+launches
- threshold.
- */
-#define APPIRATER_LOCALIZED_MESSAGE     NSLocalizedStringFromTableInBundle(@"If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!", @"AppiraterLocalizable", [Appirater bundle], nil)
-#define APPIRATER_MESSAGE				[NSString stringWithFormat:APPIRATER_LOCALIZED_MESSAGE, APPIRATER_APP_NAME]
-
-/*
- This is the title of the message alert that users will see.
- */
-#define APPIRATER_LOCALIZED_MESSAGE_TITLE   NSLocalizedStringFromTableInBundle(@"Rate %@", @"AppiraterLocalizable", [Appirater bundle], nil)
-#define APPIRATER_MESSAGE_TITLE             [NSString stringWithFormat:APPIRATER_LOCALIZED_MESSAGE_TITLE, APPIRATER_APP_NAME]
-
-/*
- The text of the button that rejects reviewing the app.
- */
-#define APPIRATER_CANCEL_BUTTON			NSLocalizedStringFromTableInBundle(@"No, Thanks", @"AppiraterLocalizable", [Appirater bundle], nil)
-
-/*
- Text of button that will send user to app review page.
- */
-#define APPIRATER_LOCALIZED_RATE_BUTTON NSLocalizedStringFromTableInBundle(@"Rate %@", @"AppiraterLocalizable", [Appirater bundle], nil)
-#define APPIRATER_RATE_BUTTON			[NSString stringWithFormat:APPIRATER_LOCALIZED_RATE_BUTTON, APPIRATER_APP_NAME]
-
-/*
- Text for button to remind the user to review later.
- */
-#define APPIRATER_RATE_LATER			NSLocalizedStringFromTableInBundle(@"Remind me later", @"AppiraterLocalizable", [Appirater bundle], nil)
 
 @interface Appirater : NSObject <UIAlertViewDelegate, SKStoreProductViewControllerDelegate> {
 
@@ -97,6 +59,7 @@ extern NSString *const kAppiraterReminderRequestDate;
 #else
 @property(nonatomic, unsafe_unretained) NSObject <AppiraterDelegate> *delegate;
 #endif
+@property(nonatomic, strong) NSObject <AppiraterDataSource> *dataSource;
 
 /*
  Tells Appirater that the app has launched, and on devices that do NOT
@@ -229,6 +192,11 @@ extern NSString *const kAppiraterReminderRequestDate;
  Set the delegate if you want to know when Appirater does something
  */
 + (void)setDelegate:(id<AppiraterDelegate>)delegate;
+
+/*
+ Set the dataSource if you want to provide Appirater with your own literals
+ */
++ (void)setDataSource:(id<AppiraterDataSource>)dataSource;
 
 /*
  Set whether or not Appirater uses animation (currently respected when pushing modal StoreKit rating VCs).

--- a/Appirater.m
+++ b/Appirater.m
@@ -35,6 +35,7 @@
  */
 
 #import "Appirater.h"
+#import "DefaultDataSource.h"
 #import <SystemConfiguration/SCNetworkReachability.h>
 #include <netinet/in.h>
 
@@ -64,6 +65,7 @@ static BOOL _debug = NO;
 #else
 	__weak static id<AppiraterDelegate> _delegate;
 #endif
+static id<AppiraterDataSource>_dataSource;
 static BOOL _usesAnimation = TRUE;
 static UIStatusBarStyle _statusBarStyle;
 static BOOL _modalOpen = false;
@@ -107,6 +109,9 @@ static BOOL _alwaysUseMainBundle = NO;
 }
 + (void)setDelegate:(id<AppiraterDelegate>)delegate{
 	_delegate = delegate;
+}
++ (void)setDataSource:(id<AppiraterDataSource>)dataSource {
+	_dataSource = dataSource;
 }
 + (void)setUsesAnimation:(BOOL)animation {
 	_usesAnimation = animation;
@@ -196,6 +201,10 @@ static BOOL _alwaysUseMainBundle = NO;
         dispatch_once(&onceToken, ^{
             appirater = [[Appirater alloc] init];
 			appirater.delegate = _delegate;
+            if (_dataSource == nil) {
+                _dataSource = [[DefaultDataSource alloc] init];
+            }
+            appirater.dataSource = _dataSource;
             [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appWillResignActive) name:
                 UIApplicationWillResignActiveNotification object:nil];
         });
@@ -205,11 +214,11 @@ static BOOL _alwaysUseMainBundle = NO;
 }
 
 - (void)showRatingAlert {
-	UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:APPIRATER_MESSAGE_TITLE
-														 message:APPIRATER_MESSAGE
+	UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:_dataSource.messageTitle
+														 message:_dataSource.message
 														delegate:self
-											   cancelButtonTitle:APPIRATER_CANCEL_BUTTON
-											   otherButtonTitles:APPIRATER_RATE_BUTTON, APPIRATER_RATE_LATER, nil];
+											   cancelButtonTitle:_dataSource.cancelButtonTitle
+											   otherButtonTitles:_dataSource.rateNowButtonTitle, _dataSource.rateLaterButtonTitle, nil];
 	self.ratingAlert = alertView;
     [alertView show];
 

--- a/Appirater.podspec
+++ b/Appirater.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = 'Appirater'
-  s.version               = '2.0.2'
+  s.version               = '2.6.0'
   s.ios.deployment_target = '5.0'
   s.summary               = "A utility that reminds your iPhone app's users to review the app."
   s.homepage              = 'http://arashpayan.com/blog/2009/09/07/presenting-appirater/'

--- a/AppiraterDataSource.h
+++ b/AppiraterDataSource.h
@@ -1,0 +1,47 @@
+//
+//  AppiraterDataSource.h
+//
+//  Created by Bram Huenaerts on 17/10/13.
+//  Copyright (c) 2013 chronux. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class Appirater;
+
+@protocol AppiraterDataSource <NSObject>
+
+@optional
+
+/*
+ Your localized app's name.
+ */
+-(NSString *)appName;
+
+/*
+ This is the message your users will see once they've passed the day+launches
+ threshold.
+ */
+-(NSString *)message;
+
+/*
+ This is the title of the message alert that users will see.
+ */
+-(NSString *)messageTitle;
+
+/*
+ The text of the button that rejects reviewing the app.
+ */
+-(NSString *)cancelButtonTitle;
+
+/*
+ Text of button that will send user to app review page.
+ */
+-(NSString *)rateNowButtonTitle;
+
+/*
+ Text for button to remind the user to review later.
+ */
+-(NSString *)rateLaterButtonTitle;
+
+@end

--- a/DefaultDataSource.h
+++ b/DefaultDataSource.h
@@ -1,0 +1,13 @@
+//
+//  DefaultDataSource.h
+//
+//  Created by Bram Huenaerts on 17/10/13.
+//  Copyright (c) 2013 chronux. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "AppiraterDataSource.h"
+
+@interface DefaultDataSource : NSObject <AppiraterDataSource>
+
+@end

--- a/DefaultDataSource.m
+++ b/DefaultDataSource.m
@@ -1,0 +1,43 @@
+//
+//  DefaultDataSource.m
+//
+//  Created by Bram Huenaerts on 17/10/13.
+//  Copyright (c) 2013 chronux. All rights reserved.
+//
+
+#import "DefaultDataSource.h"
+#import "Appirater.h"
+
+@implementation DefaultDataSource
+
+-(NSString *)appName {
+    return [[[NSBundle mainBundle] localizedInfoDictionary] objectForKey:@"CFBundleDisplayName"];
+}
+
+-(NSString *)message {
+    NSString *localizedMessage = NSLocalizedStringFromTableInBundle(@"If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!", @"AppiraterLocalizable", [Appirater bundle], nil);
+    
+    return [NSString stringWithFormat:localizedMessage, self.appName];
+}
+
+-(NSString *)messageTitle {
+    NSString *localizedMessage = NSLocalizedStringFromTableInBundle(@"Rate %@", @"AppiraterLocalizable", [Appirater bundle], nil);
+    
+    return [NSString stringWithFormat:localizedMessage, self.appName];
+}
+
+-(NSString *)cancelButtonTitle {
+    return NSLocalizedStringFromTableInBundle(@"No, Thanks", @"AppiraterLocalizable", [Appirater bundle], nil);
+}
+
+-(NSString *)rateNowButtonTitle {
+    NSString *localizedMessage = NSLocalizedStringFromTableInBundle(@"Rate %@", @"AppiraterLocalizable", [Appirater bundle], nil);
+    
+    return [NSString stringWithFormat:localizedMessage, self.appName];
+}
+
+-(NSString *)rateLaterButtonTitle {
+    return NSLocalizedStringFromTableInBundle(@"Remind me later", @"AppiraterLocalizable", [Appirater bundle], nil);
+}
+
+@end


### PR DESCRIPTION
Dear Mr Payan, with the use of a dataSource protocol, users could use their own literals easily with just the creation of a separate dataSource implementation. I also implemented a DefaultDataSource so the behaviour is the same as on the master.

Could you review this and consider this pull request. That way, we can still use the pod file in future.

King regards,

Bram 
