### PR TITLE
Added ability to trigger a prompt if all ratings conditions have been met without needing to increment any ratings attributes

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -154,6 +154,14 @@ extern NSString *const kAppiraterReminderRequestDate;
 + (void)showPrompt;
 
 /*
+ Tells Appirater to show the prompt if the the rating conditions have been met
+ however it does not increment any of the rating conditions. This is useful
+ if you want to show the prompt in a place other than were a significant event
+ occurs.
+  */
++ (void)showPromptIfRatingConditionsMet;
+
+/*
  Tells Appirater to open the App Store page where the user can specify a
  rating for the app. Also records the fact that this has happened, so the
  user won't be prompted again to rate the app.

--- a/Appirater.m
+++ b/Appirater.m
@@ -438,6 +438,21 @@ static BOOL _alwaysUseMainBundle = NO;
     }
 }
 
++ (void)showPromptIfRatingConditionsMet {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0),
+                   ^{
+                       if (canPromptForRating &&
+                           [self ratingConditionsHaveBeenMet] &&
+                           [self connectedToNetwork])
+                       {
+                           dispatch_async(dispatch_get_main_queue(),
+                                          ^{
+                                              [self showRatingAlert];
+                                          });
+                   });
+	}
+}
+
 + (id)getRootViewController {
     UIWindow *window = [[UIApplication sharedApplication] keyWindow];
     if (window.windowLevel != UIWindowLevelNormal) {


### PR DESCRIPTION
I wanted to be able to trigger a prompt if all rating conditions have been meet without having to increment any rating attributes.

Basically this means you can show the prompt (if conditions are met) at any time instead of when a significant event occurs.
