### PR TITLE
added userDidSignificantEvent method to handle weighted significant events

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -144,6 +144,12 @@ extern NSString *const kAppiraterReminderRequestDate;
 + (void)userDidSignificantEvent:(BOOL)canPromptForRating;
 
 /*!
+ Similar to +userDidSignificantEvent: but this method will increase the significant
+ event count by the quantity provided.
+ */
++ (void)userDidSignificantEvent:(BOOL)canPromptForRating withQuantity:(NSInteger)quantity;
+
+/*!
  Tells Appirater to try and show the prompt (a rating alert). The prompt will be showed
  if there is connection available, the user hasn't declined to rate
  or hasn't rated current version.

--- a/Appirater.m
+++ b/Appirater.m
@@ -329,7 +329,7 @@ static BOOL _alwaysUseMainBundle = NO;
 	[userDefaults synchronize];
 }
 
-- (void)incrementSignificantEventCount {
+- (void)incrementSignificantEventCountWithQuantity:(NSInteger)quantity {
 	// get the app's version
 	NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString*)kCFBundleVersionKey];
 	
@@ -357,7 +357,7 @@ static BOOL _alwaysUseMainBundle = NO;
 		
 		// increment the significant event count
 		NSInteger sigEventCount = [userDefaults integerForKey:kAppiraterSignificantEventCount];
-		sigEventCount++;
+		sigEventCount += quantity;
 		[userDefaults setInteger:sigEventCount forKey:kAppiraterSignificantEventCount];
 		if (_debug)
 			NSLog(@"APPIRATER Significant event count: %@", @(sigEventCount));
@@ -368,7 +368,7 @@ static BOOL _alwaysUseMainBundle = NO;
 		[userDefaults setObject:version forKey:kAppiraterCurrentVersion];
 		[userDefaults setDouble:0 forKey:kAppiraterFirstUseDate];
 		[userDefaults setInteger:0 forKey:kAppiraterUseCount];
-		[userDefaults setInteger:1 forKey:kAppiraterSignificantEventCount];
+		[userDefaults setInteger:quantity forKey:kAppiraterSignificantEventCount];
 		[userDefaults setBool:NO forKey:kAppiraterRatedCurrentVersion];
 		[userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
 		[userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
@@ -391,8 +391,8 @@ static BOOL _alwaysUseMainBundle = NO;
 	}
 }
 
-- (void)incrementSignificantEventAndRate:(BOOL)canPromptForRating {
-	[self incrementSignificantEventCount];
+- (void)incrementSignificantEventWithQuantity:(NSInteger)quantity andRate:(BOOL)canPromptForRating {
+	[self incrementSignificantEventCountWithQuantity:quantity];
 	
 	if (canPromptForRating &&
 		[self ratingConditionsHaveBeenMet] &&
@@ -446,9 +446,13 @@ static BOOL _alwaysUseMainBundle = NO;
 }
 
 + (void)userDidSignificantEvent:(BOOL)canPromptForRating {
+	[self userDidSignificantEvent:canPromptForRating withQuantity:1];
+}
+
++ (void)userDidSignificantEvent:(BOOL)canPromptForRating withQuantity:(NSInteger)quantity {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0),
                    ^{
-                       [[Appirater sharedInstance] incrementSignificantEventAndRate:canPromptForRating];
+                       [[Appirater sharedInstance] incrementSignificantEventWithQuantity:quantity andRate:canPromptForRating];
                    });
 }
 


### PR DESCRIPTION
Some significant events are more significant than others. This allows a developer to choose application specific weights to assign to events in different locations in their code. Example: 'Like'ing an article would be worth 1, creating an article would be worth 5.
