### PR TITLE
Update Appirater.m

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -607,7 +607,7 @@ static BOOL _alwaysUseMainBundle = NO;
 		NSString *reviewURL = [templateReviewURL stringByReplacingOccurrencesOfString:@"APP_ID" withString:[NSString stringWithFormat:@"%@", _appId]];
 
 		// iOS 7 needs a different templateReviewURL @see https://github.com/arashpayan/appirater/issues/131
-		if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0) {
+		if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"7.0") && SYSTEM_VERSION_LESS_THAN(@"7.1")) {
 			reviewURL = [templateReviewURLiOS7 stringByReplacingOccurrencesOfString:@"APP_ID" withString:[NSString stringWithFormat:@"%@", _appId]];
 		}
 


### PR DESCRIPTION
Replacing iTunes review URL only when version is equal or greater than 7.0 but smaller than 7.1. Since the URL issue was resolved on iOS 7.1. Previous float comparison would not work for such comparison.
