### PR TITLE
Fix for issue #179

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -273,7 +273,7 @@ static BOOL _alwaysUseMainBundle = NO;
                                            message:self.alertMessage
                                           delegate:self
                                  cancelButtonTitle:self.alertCancelTitle
-                                 otherButtonTitles:self.alertRateTitle, _alertRateLaterTitle, nil];
+                                 otherButtonTitles:self.alertRateTitle, self.alertRateLaterTitle, nil];
   } else {
   	alertView = [[UIAlertView alloc] initWithTitle:self.alertTitle
                                            message:self.alertMessage


### PR DESCRIPTION
Swapped alert create to use self.alertRateLaterTitle instead of the synthesized name.

The previous commit used _alertRateLaterTitle which doesn't use the overridden getter.
