### PR TITLE
Resolved implicit conversion.

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -230,7 +230,7 @@ static BOOL _alwaysUseMainBundle = NO;
     SCNetworkReachabilityRef defaultRouteReachability = SCNetworkReachabilityCreateWithAddress(NULL, (struct sockaddr *)&zeroAddress);
     SCNetworkReachabilityFlags flags;
 	
-    BOOL didRetrieveFlags = SCNetworkReachabilityGetFlags(defaultRouteReachability, &flags);
+    Boolean didRetrieveFlags = SCNetworkReachabilityGetFlags(defaultRouteReachability, &flags);
     CFRelease(defaultRouteReachability);
 	
     if (!didRetrieveFlags)


### PR DESCRIPTION
`SCNetworkReachabilityGetFlags()` returns a `Boolean`, not `BOOL`. This can cause a warning/error depending on your compiler flags. As this was only used once in a conditional expression, maintaining the `Boolean` throughout should be fine.
