### PR TITLE
Suppressed deprecated implementation warnings.

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -468,9 +468,12 @@ static BOOL _alwaysUseMainBundle = NO;
     return [[NSUserDefaults standardUserDefaults] boolForKey:kAppiraterRatedCurrentVersion];
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-implementations"
 + (void)appLaunched {
 	[Appirater appLaunched:YES];
 }
+#pragma GCC diagnostic pop
 
 + (void)appLaunched:(BOOL)canPromptForRating {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0),
@@ -507,9 +510,12 @@ static BOOL _alwaysUseMainBundle = NO;
                    });
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-implementations"
 + (void)showPrompt {
   [Appirater tryToShowPrompt];
 }
+#pragma GCC diagnostic pop
 
 + (void)tryToShowPrompt {
   [[Appirater sharedInstance] showPromptWithChecks:true


### PR DESCRIPTION
Depending on your compiler flags, these deprecated method implementations may cause a warning/error. While you can disable this on a per project or per file basis, using `pragma` is a more universal solution.
