### PR TITLE
Fix direct invocation to +rateApp wich fails in iOS 8

### DIFF
--- a/Appirater.m
+++ b/Appirater.m
@@ -552,14 +552,20 @@ static BOOL _alwaysUseMainBundle = NO;
         }
     }
     
-    for (UIView *subView in [window subviews])
-    {
+    return [Appirater iterateSubViewsForViewController:window]; // iOS 8+ deep traverse
+}
+
++ (id)iterateSubViewsForViewController:(UIView *) parentView {
+    for (UIView *subView in [parentView subviews]) {
         UIResponder *responder = [subView nextResponder];
         if([responder isKindOfClass:[UIViewController class]]) {
             return [self topMostViewController: (UIViewController *) responder];
         }
+        id found = [Appirater iterateSubViewsForViewController:subView];
+        if( nil != found) {
+            return found;
+        }
     }
-    
     return nil;
 }
 


### PR DESCRIPTION
On iOS 8, the `+rateApp` function can fail when `openInAppStore = NO` because `+getRootViewController` maybe unable to effectively traverse the `UIView` hierarchy. (iOS 8 may introduce an extra `UITransitionView`)

The fix introduces a recursive deep search for the `+topMostViewController`, no longer assuming that it will be found at the root level of `[window subviews]`.

Fix applies to previous versions of iOS with no ill effect.
