### PR TITLE
Additional custom action and negative event tracking

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -41,6 +41,7 @@
 extern NSString *const kAppiraterFirstUseDate;
 extern NSString *const kAppiraterUseCount;
 extern NSString *const kAppiraterSignificantEventCount;
+extern NSString *const kAppiraterNegativeEventCount;
 extern NSString *const kAppiraterCurrentVersion;
 extern NSString *const kAppiraterRatedCurrentVersion;
 extern NSString *const kAppiraterDeclinedToRate;
@@ -143,6 +144,16 @@ extern NSString *const kAppiraterReminderRequestDate;
  */
 + (void)userDidSignificantEvent:(BOOL)canPromptForRating;
 
+
+/*!
+ Tells Appirater that the user experienced a negative event (like a crash)
+
+ If the user has experienced too many negative events, he is more likely to leave negative feedback.
+ Keep up with crash reports and update the app to keep users happy.
+
+ */
++ (void)userExperiencedNegativeEvent;
+
 /*!
  Tells Appirater to try and show the prompt (a rating alert). The prompt will be showed
  if there is connection available, the user hasn't declined to rate
@@ -234,6 +245,14 @@ extern NSString *const kAppiraterReminderRequestDate;
  */
 + (void) setSignificantEventsUntilPrompt:(NSInteger)value;
 
+
+/*!
+ A negative event is anything that can make user leave negative feedback
+ (crash, connectivity issue, etc.).  To tell Appirater that the user has experienced
+ a negative event, call the method:
+ [Appirater userExperiencedNegativeEvent:];
+ */
++ (void)setMaxNegativeEvents:(NSInteger)maxNegativeEvents;
 
 /*!
  Once the rating alert is presented to the user, they might select

--- a/Appirater.h
+++ b/Appirater.h
@@ -193,6 +193,7 @@ extern NSString *const kAppiraterReminderRequestDate;
 */
 + (void)closeModal;
 
+
 /*!
  Asks Appirater if the user has declined to rate;
 */
@@ -285,6 +286,13 @@ extern NSString *const kAppiraterReminderRequestDate;
  Set customized rate later button title for alert view.
  */
 + (void) setCustomAlertRateLaterButtonTitle:(NSString *)rateLaterTitle;
+
+/*!
+ Sets Custom Action button title. When set additional button will appear, and delegate method
+ appiraterDidSelectCustomAction: will be called.  Can be used to add "Report a problem" button,
+ that will bring up a email composition or other form to communicate with authors directly, bypassing reviews.
+ */
++ (void)setCustomActionButtonTitle:(NSString *)actionTitle;
 
 /*!
  'YES' will show the Appirater alert everytime. Useful for testing how your message

--- a/AppiraterDelegate.h
+++ b/AppiraterDelegate.h
@@ -19,4 +19,6 @@
 -(void)appiraterDidOptToRemindLater:(Appirater *)appirater;
 -(void)appiraterWillPresentModalView:(Appirater *)appirater animated:(BOOL)animated;
 -(void)appiraterDidDismissModalView:(Appirater *)appirater animated:(BOOL)animated;
+-(void)appiraterDidSelectCustomAction:(Appirater *)appirater;
+
 @end


### PR DESCRIPTION
Two features and one problem fix:

- Count negative events (crashes, connectivity issues, etc.).  Do not attempt to ask for review if number of negative events exceeds threshold

```
void uncaughtExceptionHandler(NSException *exception) {
    [Appirater userExperiencedNegativeEvent];
}
```
- Add custom button to alert view and handle user selecting new custom action in delegate. Example: Allow user to report a problem instead of leaving negative review

![image](https://cloud.githubusercontent.com/assets/408858/7718467/b2df5e74-fe7e-11e4-8848-440792ca6bf8.png)

It also fixed the problem setting the delegate.  _delegate was set in class method.