### PR TITLE
Add option for rate decline to be permanent across versions

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -274,6 +274,11 @@ extern NSString *const kAppiraterReminderRequestDate;
 + (void) setDebug:(BOOL)debug;
 
 /*!
+ Determines if Appirater should reset user declines on new versions
+ */
++ (void) setResetDeclinedToRateOnNewVersion:(BOOL)reset;
+
+/*!
  Set the delegate if you want to know when Appirater does something
  */
 + (void)setDelegate:(id<AppiraterDelegate>)delegate;

--- a/Appirater.m
+++ b/Appirater.m
@@ -60,6 +60,7 @@ static NSInteger _usesUntilPrompt = 20;
 static NSInteger _significantEventsUntilPrompt = -1;
 static double _timeBeforeReminding = 1;
 static BOOL _debug = NO;
+static BOOL _resetDeclinedToRateOnNewVersion = YES;
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_5_0
 	static id<AppiraterDelegate> _delegate;
 #else
@@ -140,6 +141,12 @@ static BOOL _alwaysUseMainBundle = NO;
 + (void) setDebug:(BOOL)debug {
     _debug = debug;
 }
+
++ (void) setResetDeclinedToRateOnNewVersion:(BOOL)reset
+{
+    _resetDeclinedToRateOnNewVersion = reset;
+}
+
 + (void)setDelegate:(id<AppiraterDelegate>)delegate{
 	_delegate = delegate;
 }
@@ -407,7 +414,10 @@ static BOOL _alwaysUseMainBundle = NO;
 		[userDefaults setInteger:1 forKey:kAppiraterUseCount];
 		[userDefaults setInteger:0 forKey:kAppiraterSignificantEventCount];
 		[userDefaults setBool:NO forKey:kAppiraterRatedCurrentVersion];
-		[userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
+        if (_resetDeclinedToRateOnNewVersion)
+        {
+            [userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
+        }
 		[userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
 	}
 	
@@ -455,7 +465,10 @@ static BOOL _alwaysUseMainBundle = NO;
 		[userDefaults setInteger:0 forKey:kAppiraterUseCount];
 		[userDefaults setInteger:1 forKey:kAppiraterSignificantEventCount];
 		[userDefaults setBool:NO forKey:kAppiraterRatedCurrentVersion];
-		[userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
+        if (_resetDeclinedToRateOnNewVersion)
+        {
+            [userDefaults setBool:NO forKey:kAppiraterDeclinedToRate];
+        }
 		[userDefaults setDouble:0 forKey:kAppiraterReminderRequestDate];
 	}
 	


### PR DESCRIPTION
We had a problem with Appirater spamming our users who declined every time we release a new version.
I added a small patch that enables making the user's decline permanent.
