### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ the library check out the [Appirater group] [appiratergroup].
 Getting Started
 ---------------
 
-###Cocoapods
-If you're new to Cocoapods [watch this](http://nsscreencast.com/episodes/5-cocoapods). To add Appirater to your app, add `pod "Appirater"` to your Podfile.
+###CocoaPods
+If you're new to CocoaPods [watch this](http://nsscreencast.com/episodes/5-cocoapods). To add Appirater to your app, add `pod "Appirater"` to your Podfile.
 
-Cocoapods support is still experimental, and might not work in all use cases. If you experience problems, open an issue and install via Git submodule
+CocoaPods support is still experimental, and might not work in all use cases. If you experience problems, open an issue and install via Git submodule
 
 ###Manually
 1. Add the Appirater code into your project.


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
