### PR TITLE
Use #import instead of @import

### DIFF
--- a/Appirater.h
+++ b/Appirater.h
@@ -34,8 +34,8 @@
  * Copyright 2012 Arash Payan. All rights reserved.
  */
 
-@import Foundation;
-@import StoreKit;
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit>
 #import "AppiraterDelegate.h"
 
 extern NSString *const kAppiraterFirstUseDate;

--- a/Appirater.h
+++ b/Appirater.h
@@ -35,7 +35,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <StoreKit/StoreKit>
+#import <StoreKit/StoreKit.h>
 #import "AppiraterDelegate.h"
 
 extern NSString *const kAppiraterFirstUseDate;

--- a/Appirater.m
+++ b/Appirater.m
@@ -34,8 +34,8 @@
  * Copyright 2012 Arash Payan. All rights reserved.
  */
 
-@import SystemConfiguration;
-@import CFNetwork;
+#import <SystemConfiguration/SystemConfiguration.h>
+#import <CFNetwork/CFNetwork.h>
 #import "Appirater.h"
 #include <netinet/in.h>
 

--- a/AppiraterDelegate.h
+++ b/AppiraterDelegate.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 News.me. All rights reserved.
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class Appirater;
 


### PR DESCRIPTION
I had issues using the current version of Appriater, as it would have required me to set the `CLANG_ENABLE_MODULES` setting to `YES`, which resulted in conflicts with other imports of C classes.

As the source of Appirater is Objective-C anyways, and a CocoaPod should not have to require specific build settings of its target, I think using the old import notation is the better solution.