### PR TITLE
Use SKStoreReviewController if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Unreleased:
+----------------------------
+* Use SKStoreReviewController if available
+  * Available on iOS > 10.3 
+  * You'll need to link the StoreKit Framework
+
 Version 2.1.0 *(2016-11-04)*
 ----------------------------
 * Fix and suppress various Xcode warnings

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ If you wanted to show the request after 5 days only you can set the following:
 [Appirater appLaunched:YES];
 ```
 
+SKStoreReviewController
+----------------------
+In iOS 10.3, [SKStoreReviewController](https://developer.apple.com/library/content/releasenotes/General/WhatsNewIniOS/Articles/iOS10_3.html) was introduced which allows rating directly within the app without any additional setup.
+
+Appirater automatically uses `SKStoreReviewController` if available. You'll need to manually link `StoreKit` in your App however.
+
+If `SKStoreReviewController` is used, Appirater is used only to decide when to show the rating dialog to the user. Keep in mind, that `SKStoreReviewController` automatically limits the number of impressions, so the dialog might be displayed less frequently than your configured conditions might suggest.
+
 Help and Support Group
 ----------------------
 Requests for help, questions about usage, suggestions and other relevant topics should be posted at the [Appirater group] [appiratergroup]. As much as I'd like to help everyone who emails me, I can't respond to private emails, but I'll respond to posts on the group where others can benefit from the Q&As.


### PR DESCRIPTION
With this, [`SKStoreReviewController`](https://developer.apple.com/library/content/releasenotes/General/WhatsNewIniOS/Articles/iOS10_3.html) is used if available. 

Since its dialog already has an option to "Rate later", this circumvents all of Appirater's UI. 
Also, `SKStoreReviewController` automatically takes care of rate limiting (I've heard something about max 3 impressions per year, no matter what i.e. regardless of app version), so Appirater also does not store the Impression for this version.

Refs https://github.com/arashpayan/appirater/issues/250 and  https://github.com/arashpayan/appirater/issues/256 