### PR TITLE
Fix Misspelled Word

### DIFF
--- a/fa.lproj/AppiraterLocalizable.strings
+++ b/fa.lproj/AppiraterLocalizable.strings
@@ -1,4 +1,4 @@
-"If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!" = "اگر از استفاده برنامه %@ لذت می‌برید، زمان دارید بهش امتیاز دهید؟  بیشتر از یک دقیقه زمان نخواهد گرفت. با تشکر از اینکه ما را همایت می‌کنید.";
+"If you enjoy using %@, would you mind taking a moment to rate it? It won't take more than a minute. Thanks for your support!" = "اگر از استفاده برنامه %@ لذت می‌برید، زمان دارید بهش امتیاز دهید؟  بیشتر از یک دقیقه زمان نخواهد گرفت. با تشکر از اینکه ما را حمایت می‌کنید.";
 "Rate %@" = "ارزیابی کردن %@";
 "No, Thanks" = "نه، مرسی";
 "Remind me later" = "بعدا";


### PR DESCRIPTION
the word "حمایت" means support is misspelled in localization file

reference: https://abadis.ir/fatofa/%D8%AD%D9%85%D8%A7%DB%8C%D8%AA/